### PR TITLE
Add Ag1000G phase 3 catalog

### DIFF
--- a/gcs.yml
+++ b/gcs.yml
@@ -8,3 +8,10 @@ sources:
     description: 'Anopheles gambiae 1000 Genomes Project, phase 2 data resource.'
     driver: intake.catalog.local.YAMLFileCatalog
     metadata: {}
+
+  ag3:
+    args:
+      path: "{{CATALOG_DIR}}/gcs/ag3.yml"
+    description: 'Anopheles gambiae 1000 Genomes Project, phase 3 data resource.'
+    driver: intake.catalog.local.YAMLFileCatalog
+    metadata: {}

--- a/gcs/ag3.yml
+++ b/gcs/ag3.yml
@@ -1,0 +1,80 @@
+metadata:
+  version: 1
+sources:
+
+  sample_sets:
+    description: 'Manifest of sample sets.'
+    driver: csv
+    args:
+      urlpath: gcs://vo_agam_release/v3/manifest.tsv
+      csv_kwargs:
+        sep: "	"
+
+  samples:
+    description: 'Sample metadata for a given sample set.'
+    driver: csv
+    parameters:
+      sample_set:
+        description: 'Sample set.'
+        type: str
+    args:
+      urlpath: gcs://vo_agam_release/v3/metadata/general/{{ sample_set }}/samples.meta.csv
+
+  species_calls_20200422_aim:
+    description: 'Species calls via ancestry informative markers for a given sample set.'
+    driver: csv
+    parameters:
+      sample_set:
+        description: 'Sample set.'
+        type: str
+    args:
+      urlpath: gcs://vo_agam_release/v3/metadata/species_calls_20200422/{{ sample_set }}/samples.species_aim.csv
+
+  species_calls_20200422_pca:
+    description: 'Species calls via principal components analysis for a given sample set.'
+    driver: csv
+    parameters:
+      sample_set:
+        description: 'Sample set.'
+        type: str
+    args:
+      urlpath: gcs://vo_agam_release/v3/metadata/species_calls_20200422/{{ sample_set }}/samples.species_pca.csv
+
+  snp_sites:
+    description: 'Genomic sites at which single nucleotide polymorphism genotypes were called.'
+    driver: zarr_cat
+    args:
+      urlpath: gcs://vo_agam_release/v3/snp_genotypes/all/sites
+      consolidated: true
+
+  snp_genotypes:
+    description: 'Single nucleotide polymorphism genotypes for a given sample set.'
+    driver: zarr_cat
+    parameters:
+      sample_set:
+        description: 'Sample set.'
+        type: str
+    args:
+      urlpath: 'gcs://vo_agam_release/v3/snp_genotypes/all/{{sample_set}}/'
+      consolidated: true
+
+  site_filters_dt_20200416_arab:
+    description: 'Site filters for use with SNP data for An. arabiensis samples.'
+    driver: zarr_cat
+    args:
+      urlpath: gcs://vo_agam_release/v3/site_filters/dt_20200416/arab
+      consolidated: true
+
+  site_filters_dt_20200416_gamb_colu:
+    description: 'Site filters for use with SNP data for An. gambiae and/or An. coluzzii samples.'
+    driver: zarr_cat
+    args:
+      urlpath: gcs://vo_agam_release/v3/site_filters/dt_20200416/gamb_colu
+      consolidated: true
+
+  site_filters_dt_20200416_gamb_colu_arab:
+    description: 'Site filters for use with SNP data for An. gambiae, An. coluzzii and/or An. arabiensis samples.'
+    driver: zarr_cat
+    args:
+      urlpath: gcs://vo_agam_release/v3/site_filters/dt_20200416/gamb_colu_arab
+      consolidated: true

--- a/gcs/ag3.yml
+++ b/gcs/ag3.yml
@@ -54,6 +54,7 @@ sources:
       sample_set:
         description: 'Sample set.'
         type: str
+        default: AG1000G-AO
     args:
       urlpath: 'gcs://vo_agam_release/v3/snp_genotypes/all/{{sample_set}}/'
       consolidated: true


### PR DESCRIPTION
This PR adds a sub-catalog for the Ag1000G phase 3 data, including sample metadata, species calls, SNP genotypes, SNP sites and site filters.

Currently the `snp_genotypes` entry doesn't work due to https://github.com/intake/intake/issues/505.